### PR TITLE
East Germanic for the Visigoths

### DIFF
--- a/CK2Plus/common/cultures/00_cultures.txt
+++ b/CK2Plus/common/cultures/00_cultures.txt
@@ -635,6 +635,11 @@ west_germanic = {
 
 		modifier = default_culture_modifier
 	}
+}
+
+east_germanic = {
+	graphical_cultures = { germangfx }
+
 	visigothic = {
 		graphical_cultures = { southerngfx }
 		

--- a/CK2Plus/localisation/zz_CK2Plus_cultures.csv
+++ b/CK2Plus/localisation/zz_CK2Plus_cultures.csv
@@ -32,3 +32,4 @@ assyrian;Assyrian;Assyrian;Assyrian;;Assyrian;;;;;;;;;x
 aramaic;Aramaic;Aramaic;Aramaic;;Aramaic;;;;;;;;;x
 beja;Beja;Beja;Beja;;Beja;;;;;;;;;x
 songhai;Songhai;Songhai;Songhai;;Songhai;;;;;;;;;x
+east_germanic;East Germanic;Est Germanique;Ostgermanischen;Este Germánico;;;;;;x


### PR DESCRIPTION
Creates the East Germanic group for the Visigoths and adds the Visigoths
to the group. As they are an East Germanic Language rather than West
Germanic
