### PR TITLE
Quick Religion Fix

### DIFF
--- a/CK2Plus/common/religions/00_religions.txt
+++ b/CK2Plus/common/religions/00_religions.txt
@@ -1975,7 +1975,6 @@ pagan_group = {
 	}
 
 	arab_pagan = {
-		parent = sunni
 		graphical_culture = muslimgfx
 		
 		icon = 77


### PR DESCRIPTION
Arab Pagan had Sunni flagged as its parent religion. This caused it to
be represented as muslim in-game including using the muslim heresy icon
instead of its correct icon. This fixes the issue in new games. Saves
are unchanged.
