### PR TITLE
Imperial government tribal holdings fix

### DIFF
--- a/CK2Plus/common/governments/feudal_governments.txt
+++ b/CK2Plus/common/governments/feudal_governments.txt
@@ -493,6 +493,7 @@ feudal_governments = {
 			is_patrician = no
 			could_be_temporal_religious_head_trigger = yes
 		}
+		can_build_tribal = no
 
 		dukes_called_kings = yes
 		barons_need_dynasty = yes


### PR DESCRIPTION
Fix of the issue: https://github.com/ck2plus/CK2Plus/issues/232

And apparently order_government doesn't have "can_build_tribal = no" both in the mod and in vanilla. I didn't change that. Not sure if it's intended or it's a bug.