### PR TITLE
Fix Issue #231, city stables of level > 1 not available outside of steppes and deserts

### DIFF
--- a/CK2Plus/common/buildings/00_CK2Plus_city.txt
+++ b/CK2Plus/common/buildings/00_CK2Plus_city.txt
@@ -573,6 +573,10 @@ city = {
 
 		camel_cavalry = 56
 
+		potential = {
+			terrain = desert
+		}
+
 		trigger = {
 			TECH_CAVALRY >= 1
 			ai_can_build_trigger = yes
@@ -588,6 +592,10 @@ city = {
 		extra_tech_building_start = 0.8
 
 		camel_cavalry = 66
+
+		potential = {
+			terrain = desert
+		}
 
 		trigger = {
 			TECH_CAVALRY >= 3
@@ -606,6 +614,10 @@ city = {
 		camel_cavalry = 66
 		knights = 15
 
+		potential = {
+			terrain = desert
+		}
+
 		trigger = {
 			TECH_CAVALRY >= 5
 			ai_can_build_trigger = yes
@@ -622,6 +634,10 @@ city = {
 
 		camel_cavalry = 66
 		knights = 20
+
+		potential = {
+			terrain = desert
+		}
 
 		trigger = {
 			TECH_CAVALRY >= 7


### PR DESCRIPTION
Fix issue #231.

City stables of level 2-5 are currently unavailable in normal cities, as they're being replaced in all cases by the special desert stables, ct_desert_stable_2, etc.

Fix is to restrict special desert stables to desert terrain cities. 