### PR TITLE
Fix Issue #236, plot event Plus.205 never fires when fabricating treason as a liege against one of your vassals

### DIFF
--- a/CK2Plus/events/CK2Plus_plot_events.txt
+++ b/CK2Plus/events/CK2Plus_plot_events.txt
@@ -2288,15 +2288,13 @@ character_event = {
 	prisoner = no
 
 	trigger = {
-		OR = {
-			has_plot = plot_fabricate_treason
-			has_plot = plot_fabricate_treason_liege
-		}
+
+		has_plot = plot_fabricate_treason_liege
 
 		is_plot_active = no
 
 		plot_target_char = {
-			NOT = { vassal_of = ROOT }
+			vassal_of = ROOT
 		}
 	}
 


### PR DESCRIPTION
Plot `plot_fabricate_treason_liege` is supposed to be used when a liege is fabricating treason against one of his/her own vassals.

Event `Plus.205` should provide the actual action of the plot, but has

```
plot_target_char = {
	NOT = { vassal_of = ROOT }
}
```

and so never fires if the target is your vassal. Thus, the plot never does anything (or than possibly be exposed).

Tested by starting a 769 game as Caliph Al-Mansur. Was able to fabricate treason against a Christian vassal within a few months with ~750% plot power.