### PR TITLE
Fix Issue #243, wrong character ID assigned as mother to Amelung Billung

### DIFF
--- a/CK2Plus/history/characters/saxon.txt
+++ b/CK2Plus/history/characters/saxon.txt
@@ -134,7 +134,7 @@
 		birth = yes
 	}
 	739.1.1 = {
-		add_spouse = 1000061100 # Meili
+		add_spouse = 1000061001 # Meili
 	}
 	762.1.1 = {
 		death = yes
@@ -147,7 +147,7 @@
 	religion = german_pagan
 	culture = saxon
 	father = 190462 # Æthelberht II
-	mother = 1000061100 # Meili
+	mother = 1000061001 # Meili
 	745.1.1 = {
 		birth = yes
 	}


### PR DESCRIPTION
Fixes Amelung Billung having a male mother and Æthelberht Billung having no wife, both due to type in character ID assigned.