### PR TITLE
Fix missing wonder for 252 - Julich

### DIFF
--- a/CK2Plus/history/provinces/252 - Julich.txt
+++ b/CK2Plus/history/provinces/252 - Julich.txt
@@ -26,7 +26,6 @@ religion = chalcedonian
 }
 
 797.1.1 = { # Improvements made by Charlemagne
-	build_wonder = wonder_palace
 	set_wonder_stage = 2
 }
 


### PR DESCRIPTION
Fixed missing wonder on the Julich province as pointed out by Andrew42 on the CK2Plus Discord server.
This is done by removing a duplicate build_wonder command in the history files.