### PR TITLE
Fix coronating ruler inviting themselves

### DIFF
--- a/CK2Plus/common/scripted_effects/99_CK2Plus_coronation_effects.txt
+++ b/CK2Plus/common/scripted_effects/99_CK2Plus_coronation_effects.txt
@@ -157,6 +157,10 @@ send_coronation_invitations_effect = {
 						ROOT = {
 							rightful_religious_head = PREV # He's either performing it or not coming at all
 						}
+
+						event_target:coronation_ruler = {
+							character = ROOT # The ruler is the one holding the coronation
+						}
 					}
 				}
 


### PR DESCRIPTION
Excludes the coronating ruler from potential rulers to invite.

So far tested by playing as Petty King of York in 867, gave myself the Titular Kingdom of York through console commands, ended the war by imprisoning the Petty King of Northumbria through console commands, and picked the Royal Coronation intrigue decision. No letter event (Plus.1201) was sent to myself when compared to previous plays.

~~Needs further testing by me with imperial coronation and review if there are any problems.~~
Seems to work with Imperial Coronation work no other problems.