### PR TITLE
Add working-tree-encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # Set Encoding to ANSI/Windows-1252
-* encoding=Windows-1252
+* encoding=cp1252
+*.txt working-tree-encoding=cp1252 git-encoding=cp1252
+*.csv working-tree-encoding=cp1252 git-encoding=cp1252
+*.info working-tree-encoding=cp1252 git-encoding=cp1252
 
 # Auto detect text files and perform LF normalization
 * text=auto


### PR DESCRIPTION
Giving this another try. GitKraken *seems* to support it now.