### PR TITLE
Replace Murchad mac Donnchada with Toirdelbach mac Tadg as king of Munster

### DIFF
--- a/CK2Plus/history/titles/c_thomond.txt
+++ b/CK2Plus/history/titles/c_thomond.txt
@@ -1,0 +1,255 @@
+370.1.1 = {
+	holder = 83607 # Conall Corc
+}
+
+420.1.1 = {
+	holder = 83608 # Nad Froich
+}
+
+450.1.1 = {
+	holder = 83735 # Ailill son of Nad Froich
+}
+
+490.1.1 = {
+	holder = 83736 # Crimthann son of Ailill
+}
+
+492.1.1 = {
+	holder = 83610 # Eochaid son of Óengus son of Nad Froich
+}
+
+520.1.1 = {
+	holder = 83737 # Éndae son of Crimthann
+}
+
+551.1.1 = {
+	holder = 83616 # Crimthann grandson of Eochaid
+}
+
+562.1.1 = {
+	holder = 83765 # Coirpre Cromm son of Crimthann
+}
+
+580.1.1 = {
+	holder = 83738 # Amalgaid son of Éndae
+}
+
+590.1.1 = {
+	holder = 83739 # Garbán son of Éndae
+}
+
+594.1.1 = {
+	holder = 83767 # Feidlimid son of Coirpre Cromm
+}
+
+617.1.1 = {
+	holder = 83768 # Cathal son of Áed Fland
+}
+
+628.1.1 = {
+	holder = 83740 # Cúán son of Amalgaid
+}
+
+641.1.1 = {
+	holder = 83769 # Cathal Cú-Cen-Máthair son of Cathal son of Áed Fland
+}
+
+679.1.1 = {
+	holder = 83770 # Finguine son of Cathal Cú-Cen-Máthair
+}
+
+696.1.1 = {
+	holder = 83771 # Ailill son of Cathal Cú-Cen-Máthair
+}
+
+701.1.1 = {
+	holder = 83743 # Eterscél son of Máel-Umai
+}
+
+721.1.1 = {
+	holder = 83744 # Cathussach son of Eterscél
+}
+
+733.1.1 = {
+	holder = 83772 # Cathal son of Finguine
+}
+
+742.1.1 = {
+	holder = 83748 # Cathussach
+}
+
+769.1.1 = {
+	holder = 83789 # Máel-Dúin
+}
+
+786.1.1 = {
+	holder = 83746 # Ólchobar son of Dub-Indrecht
+}
+
+793.1.1 = {
+	holder = 83773 # Artrí son of Cathal
+}
+
+821.1.1 = {
+	holder = 83793 # Ólchobar son of Cináed
+}
+
+851.1.1 = {
+	holder = 83774 # Tuathal son of Artrí
+}
+
+859.1.1 = {
+	holder = 83763 # Cenn-Fáelad Ua Mugthigirn son of Murchad
+}
+
+872.1.1 = {
+	holder = 83672 # Dúnchad son of Dub-dá-Bairenn
+}
+
+888.1.1 = {
+	holder = 83659 # Dub-Lachtna son of Máel-Gualae
+}
+
+895.1.1 = {
+	holder = 83675 # Finguine Cenn nGécán son of Láegaire
+}
+
+902.1.1 = {
+	holder = 83692 # Lorcán son Condlígan
+}
+
+922.1.1 = {
+	holder = 83666 # Cellachán Caisil son of Buadachán
+}
+
+930.1.1 = {
+	holder = 83330 # Cennétig of Dál Cais
+	liege = d_munster
+}
+
+951.7.1 = {
+	holder = 83332 # Mathgamain mac Cennétig
+	liege = 0
+}
+
+976.7.1 = {
+	holder = 900 # Brian Bóruma mac Cennétig
+}
+
+978.7.1 = {
+	liege = d_munster
+}
+
+1014.4.23 = {
+	holder = 83647 # Dúngal son of Máel-Fothardaig
+}
+
+1024.7.1 = {
+	holder = 902 # Donnchad mac Briain
+}
+
+1063.7.1 = {
+	holder = 906 # High-King Toirrdelbach mac Taidg
+}
+
+1086.7.14 = {
+	holder = 912 # Tadg mac Toirrdelbaig
+}
+
+1086.8.1 = {
+	holder = 913 # Diarmait mac Toirrdelbaig
+}
+
+1086.12.1 = {
+	holder = 907 # High-King Muirchertach mac Toirdelbaig
+}
+
+1114.7.1 = {
+	holder = 913 # Diarmait mac Toirrdelbaig
+}
+
+1115.7.1 = {
+	holder = 907 # High-King Muirchertach mac Toirdelbaig
+}
+
+1116.7.1 = {
+	holder = 913 # Diarmait mac Toirrdelbaig
+}
+
+1118.7.1 = {
+	holder = 83357 # Brian son of Murchad
+	liege = 0
+}
+
+1118.12.1 = {
+	holder = 214590 # Toirrdellbach mac Diarmata
+}
+
+1152.7.1 = {
+	holder = 83334 # Tadg Gláe mac Diarmata
+}
+
+1154.7.1 = {
+	holder = 214590 # Toirrdellbach mac Diarmata
+}
+
+1167.7.1 = {
+	holder = 83336 # Muirchertach son of Toirrdellbach mac Diarmata
+}
+
+1168.7.1 = {
+	holder = 214580 # Domnall Mór son of Toirrdellbach mac Diarmata
+}
+
+1172.1.1 = {
+	liege = k_england
+}
+
+1185.1.1 = {
+	liege = d_meath
+}
+
+1194.7.1 = {
+	holder = 214582 # Conchobar Ruad mac Domnaill Móír
+}
+
+1203.7.1 = {
+	holder = 214583 # Donnchad Caiprech mac Domnaill Móír
+}
+
+1242.7.1 = {
+	holder = 83340 # Conchobar na Siudaine
+}
+
+1268.5.22 = {
+	holder = 83343 # Brian Ruad
+}
+
+1277.5.11 = {
+	holder = 83344 # Donnchad mac Briain Ruaid
+}
+
+1284.7.1 = {
+	holder = 454140 # Toirrdelbach son of Tadg of Cáenluisce
+}
+
+1306.8.1 = {
+	holder = 83351 # Donnchad son of Toirrdelbach
+}
+
+1311.7.1 = {
+	holder = 83347 # Diarmait Cléirech mac Donnchada
+	liege = 0
+}
+
+1313.7.1 = {
+	holder = 83348 # Donnchad mac Domnaill
+}
+
+1316.7.1 = {
+	holder = 454205 # Muirchertach son of Toirrdelbach
+}
+
+1343.7.1 = {
+	holder = 83349 # Brian Bán mac Domnaill
+}

--- a/CK2Plus/history/titles/d_munster.txt
+++ b/CK2Plus/history/titles/d_munster.txt
@@ -1,0 +1,259 @@
+370.1.1 = {
+	holder = 83607 # Conall Corc
+}
+
+420.1.1 = {
+	holder = 83608 # Nad-Froich
+}
+
+450.1.1 = {
+	holder = 83609 # Óengus
+}
+
+489.1.1 = {
+	holder = 83611 # Feidelmid
+}
+
+500.1.1 = {
+	holder = 83610 # Eochaid
+}
+
+520.1.1 = {
+	holder = 83615 # Crimthann
+}
+
+542.1.1 = {
+	holder = 83765 # Coirpre Cromm
+}
+
+577.1.1 = {
+	holder = 83757 # Fergus Scandal
+}
+
+583.1.1 = {
+	holder = 83699 # Feidlimid mac Tigernaig
+}
+
+588.1.1 = {
+	holder = 83767 # Feidlimid mac Coirpri Chruimm
+}
+
+596.1.1 = {
+	holder = 83738 # Amalgaid
+}
+
+599.1.1 = {
+	holder = 83739 # Garbán
+}
+
+601.1.1 = {
+	holder = 83619 # Fíngen
+}
+
+618.1.1 = {
+	holder = 83784 # Áed Bennán
+}
+
+619.1.1 = {
+	holder = 83768 # Cathal
+}
+
+627.1.1 = {
+	holder = 83620 # Faílbe Fland
+}
+
+639.1.1 = {
+	holder = 83740 # Cúán
+}
+
+641.1.1 = {
+	holder = 83621 # Máenach
+}
+
+661.1.1 = {
+	holder = 83769 # Cathal Cú-Cen-Máthair
+}
+
+665.1.1 = {
+	holder = 83628 # Colgú
+}
+
+678.1.1 = {
+	holder = 83770 # Finguine
+}
+
+696.1.1 = {
+	holder = 83771 # Ailill
+}
+
+701.1.1 = {
+	holder = 83624 # Cormac
+}
+
+712.1.1 = {
+	holder = 83747 # Eterscél
+}
+
+721.1.1 = {
+	holder = 83772 # Cathal
+}
+
+742.1.1 = {
+	holder = 83748 # Cathussach
+}
+
+769.1.1 = {
+	holder = 83789 # Máel-Dúin
+}
+
+786.1.1 = {
+	holder = 83746 # Ólchobar son of Dub-Indrecht
+}
+
+805.1.1 = {
+	holder = 83773 # Artrí son of Cathal
+}
+
+807.1.1 = {
+	holder = 83655 # Tnúthgal
+}
+
+817.1.1 = {
+	holder = 83774 # Tuathal
+}
+
+820.1.1 = {
+	holder = 83633 # Feidlimid
+}
+
+847.1.1 = {
+	holder = 83793 # Ólchobar son of Cináed
+}
+
+851.1.1 = {
+	holder = 83657 # Áilgenán
+}
+
+853.1.1 = {
+	holder = 83658 # Máel-Gualae
+}
+
+859.1.1 = {
+	holder = 83763 # Cenn-Fáelad
+}
+
+872.1.1 = {
+	holder = 83672 # Dúnchad son of Dub-dá-Bairenn
+}
+
+888.1.1 = {
+	holder = 83659 # Dub-Lachtna son of Máel-Gualae
+}
+
+895.1.1 = {
+	holder = 83675 # Finguine Cenn nGécán son of Láegaire
+}
+
+902.1.1 = {
+	holder = 83685 # Cormac mac Cuilenn‡in
+}
+
+908.1.1 = {
+	holder = 83692 # Lorcán son Condlígan
+}
+
+922.1.1 = {
+	holder = 252134 # Flaithbertach
+}
+
+944.1.1 = {
+	holder = 83666 # Cellachán Caisil son of Buadachán
+}
+
+954.1.1 = {
+	holder = 83646 # Máel-Fathardaig
+}
+
+957.1.1 = {
+	holder = 83733 # Dub-dá-Bairenn
+}
+
+959.1.1 = {
+	holder = 83662 # Fer-Gráid
+}
+
+961.1.1 = {
+	holder = 83667 # Donnchad
+}
+
+963.1.1 = {
+	holder = 166120 # Máel-Muad
+}
+
+970.7.1 = {
+	holder = 83332 # Mathgamain mac Cennétig
+}
+
+976.1.1 = {
+	holder = 166120 # Máel-Muad
+}
+
+978.7.1 = {
+	holder = 900 # Brian Bóruma mac Cennétig
+}
+
+1014.4.23 = {
+	holder = 83647 # Dœngal Hua Donnchada
+}
+
+1024.7.1 = {
+	holder = 902 # Donnchad mac Briain
+}
+
+1063.7.1 = {
+	holder = 906 # High-King Toirrdelbach mac Taidg
+}
+
+1086.7.14 = {
+	holder = 912 # Tadg mac Toirrdelbaig
+}
+
+1086.8.1 = {
+	holder = 913 # Diarmait mac Toirrdelbaig
+}
+
+1086.12.1 = {
+	holder = 907 # High-King Muirchertach mac Toirdelbaig
+}
+
+1114.7.1 = {
+	holder = 913 # Diarmait mac Toirrdelbaig
+}
+
+1115.7.1 = {
+	holder = 907 # High-King Muirchertach mac Toirdelbaig
+}
+
+1116.7.1 = {
+	holder = 913 # Diarmait mac Toirrdelbaig
+}
+
+1118.7.1 = {
+	holder = 83254 # Tadg son of Muiredach Mac Cairthaigh
+}
+
+1124.7.1 = {
+	holder = 83255 # Cormac son of Muiredach Mac Cairthaigh
+}
+
+1138.7.1 = {
+	holder = 83256 # Donnchad son of Muiredach Mac Cairthaigh
+}
+
+1143.7.1 = {
+	holder = 214610 # Diarmait son of Cormac Mac Cairthaigh
+}
+
+1172.1.1 = {
+	holder = 0
+}


### PR DESCRIPTION
This piece of ahistorical information was added to Wikipedia in 2006 based on a misreading of the book Irish Kings and High Kings. Paradox copied it into their history files when creating Crusader Kings 2; the original game correctly assigned Toirdelbach as king of Munster from 1063 (when he deposed Donnchad, who went on pilgramage to Rome and died there the following year; Murchad spent the rest of his life trying unsuccessfully to unseat Toirdelbach). As a result of the Youtuber [Maniacal Inc.'s video](https://www.youtube.com/watch?v=tX6W0H9R7yc) they added a game rule to fix it in Crusader Kings 3, but they've never come back and fixed it in Crusader Kings 2.